### PR TITLE
Fix/general fix 0210

### DIFF
--- a/components/Home/Cards/InlineJobCard.tsx
+++ b/components/Home/Cards/InlineJobCard.tsx
@@ -38,7 +38,7 @@ const InlineJobCard = ({
         <div className="relative flex h-9 w-9 shrink-0 items-center justify-center">
           <Image src={logo} fill priority alt="Logo" className="object-cover" />
         </div>
-        <div className="flex max-w-[200px] flex-col gap-y-1 lg:max-w-full">
+        <div className="flex max-w-[155px] flex-col gap-y-1 md:max-w-[500px] xl:max-w-[200px]">
           <span className="lg:body-6 body-10 lg:body-15 line-clamp-1 text-black dark:text-white">
             {job_title}
           </span>

--- a/components/JDJobCardLarge.tsx
+++ b/components/JDJobCardLarge.tsx
@@ -113,7 +113,11 @@ const JDJobCardLarge = ({
               Experience
             </span>
             <span className="text-sm font-semibold not-italic leading-6 text-natural-8 dark:text-white md:text-base">
-              {job_required_experience?.required_experience_in_months ?? "N/A"}
+              {job_required_experience?.required_experience_in_months
+                ? `${Math.round(
+                    job_required_experience.required_experience_in_months / 12
+                  )} years`
+                : "N/A"}
             </span>
           </div>
 


### PR DESCRIPTION
- Changed experience section from months to years since that is more common
<img width="732" alt="Screenshot 2024-02-10 at 10 32 19 PM" src="https://github.com/asakohayase/JobIt-JobFinder/assets/76857882/2f195a60-633d-4f27-8a66-f7be1aa3aca3">

- Adjusted max width for inline jobcard so that it will truncate the texts when they exceeded the width.

<img width="324" alt="Screenshot 2024-02-10 at 11 23 09 PM" src="https://github.com/asakohayase/JobIt-JobFinder/assets/76857882/9559b162-8763-492e-ad07-661052643c08">
